### PR TITLE
Fix pango-designation update

### DIFF
--- a/pangolin/command.py
+++ b/pangolin/command.py
@@ -493,7 +493,7 @@ def update(version_dictionary, data_dir=None):
         #print(dependency, version, latest_release)
         # to match the tag names add a v to the pangolin internal version
         if dependency in ['pangolin', 'scorpio', 'pango-designation']:
-            version = "v" + version
+            if (not version.startswith('v')): version = "v" + version
         # to match the tag names for pangoLEARN add data release
         elif dependency == 'pangolearn':
             version = version.replace(' ', ' data release ')


### PR DESCRIPTION
When I made the update it gave me this message:
"pango-designation (vv1.2.13) is newer than latest stable release (v1.2.86), not updating."